### PR TITLE
Modified frontend Dockerfile to not use name builder

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine as build
+FROM node:14-alpine
 WORKDIR /app
 COPY  package.json .
 COPY  package-lock.json .
@@ -8,6 +8,6 @@ RUN npm run build
 
 FROM nginx:stable-alpine
 COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
-COPY --from=build /app/build /usr/share/nginx/html
+COPY --from=0 /app/build /usr/share/nginx/html
 EXPOSE 3000
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Tried to fix 502 Bad Gateway by removing the named builder (frontend) and use the number instead.